### PR TITLE
fix(backend:s3): fix passing a client reference, close #18

### DIFF
--- a/ecs.php
+++ b/ecs.php
@@ -2,24 +2,24 @@
 
 declare(strict_types=1);
 
-use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
-use Symplify\EasyCodingStandard\ValueObject\Option;
+use Symplify\EasyCodingStandard\Config\ECSConfig;
 use Symplify\EasyCodingStandard\ValueObject\Set\SetList;
 
-return static function (ContainerConfigurator $containerConfigurator): void {
-    $parameters = $containerConfigurator->parameters();
-    $parameters->set(Option::PATHS, [
+return static function (ECSConfig $ecsConfig): void {
+    $ecsConfig->paths([
         __DIR__ . '/src',
         __DIR__ . '/tests',
         __DIR__ . '/playground/symfony-5.4/src',
         __DIR__ . '/playground/symfony-6.0/src',
     ]);
-    $parameters->set(Option::SKIP, [
+
+    $ecsConfig->skip([
         __DIR__ . '/src/_connector',
     ]);
 
-    $containerConfigurator->import(SetList::PSR_12);
-    $containerConfigurator->import(SetList::CLEAN_CODE);
-    $containerConfigurator->import(SetList::SYMFONY);
-    $containerConfigurator->import(SetList::PHPUNIT);
+    $ecsConfig->sets([
+        SetList::PSR_12,
+        SetList::CLEAN_CODE,
+        SetList::PHPUNIT,
+    ]);
 };

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -11,6 +11,11 @@ parameters:
 			path: src/Controller/CKFinderController.php
 
 		-
+			message: "#^Method CKSource\\\\Bundle\\\\CKFinderBundle\\\\DependencyInjection\\\\CKSourceCKFinderExtension\\:\\:registerServicesMap\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/DependencyInjection/CKSourceCKFinderExtension.php
+
+		-
 			message: "#^Call to an undefined method Symfony\\\\Component\\\\Config\\\\Definition\\\\Builder\\\\NodeDefinition\\:\\:append\\(\\)\\.$#"
 			count: 1
 			path: src/DependencyInjection/Configuration.php

--- a/rector.php
+++ b/rector.php
@@ -2,31 +2,28 @@
 
 declare(strict_types=1);
 
-use Rector\Core\Configuration\Option;
-use Rector\Php74\Rector\Property\TypedPropertyRector;
+use Rector\Config\RectorConfig;
 use Rector\Set\ValueObject\LevelSetList;
 use Rector\Set\ValueObject\SetList;
-use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-return static function (ContainerConfigurator $containerConfigurator): void {
-    // get parameters
-    $parameters = $containerConfigurator->parameters();
-    $parameters->set(Option::PATHS, [
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->paths([
         __DIR__ . '/src',
         __DIR__ . '/tests',
         __DIR__ . '/playground/symfony-5.4/src',
         __DIR__ . '/playground/symfony-6.0/src',
     ]);
-    $parameters->set(Option::SKIP, [
+
+    $rectorConfig->skip([
         __DIR__ . '/src/_connector',
     ]);
 
     // Define what rule sets will be applied
-    $containerConfigurator->import(LevelSetList::UP_TO_PHP_80);
-    $containerConfigurator->import(SetList::TYPE_DECLARATION);
-    $containerConfigurator->import(SetList::TYPE_DECLARATION_STRICT);
-    $containerConfigurator->import(SetList::CODE_QUALITY);
-    $containerConfigurator->import(SetList::DEAD_CODE);
+    $rectorConfig->import(LevelSetList::UP_TO_PHP_80);
+    $rectorConfig->import(SetList::TYPE_DECLARATION);
+    $rectorConfig->import(SetList::TYPE_DECLARATION_STRICT);
+    $rectorConfig->import(SetList::CODE_QUALITY);
+    $rectorConfig->import(SetList::DEAD_CODE);
 
     // get services (needed for register a single rule)
     // $services = $containerConfigurator->services();

--- a/src/Command/CKFinderDownloadCommand.php
+++ b/src/Command/CKFinderDownloadCommand.php
@@ -52,31 +52,31 @@ class CKFinderDownloadCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        if (false === $targetPublicPath = realpath(__DIR__.'/../Resources/public')) {
+        if (false === $targetPublicPath = realpath(__DIR__ . '/../Resources/public')) {
             throw new \RuntimeException('Unable to get public path.');
         }
 
         if (!is_writable($targetPublicPath)) {
-            $output->writeln('<error>The CKSourceCKFinderBundle::Resources/public directory is not writable (used path: '.$targetPublicPath.').</error>');
+            $output->writeln('<error>The CKSourceCKFinderBundle::Resources/public directory is not writable (used path: ' . $targetPublicPath . ').</error>');
 
             return 1;
         }
 
-        if (false === $targetConnectorPath = realpath(__DIR__.'/../_connector')) {
+        if (false === $targetConnectorPath = realpath(__DIR__ . '/../_connector')) {
             throw new \RuntimeException('Unable to get CKFinder connector path.');
         }
 
         if (!is_writable($targetConnectorPath)) {
-            $output->writeln('<error>The CKSourceCKFinderBundle::_connector directory is not writable (used path: '.$targetConnectorPath.').</error>');
+            $output->writeln('<error>The CKSourceCKFinderBundle::_connector directory is not writable (used path: ' . $targetConnectorPath . ').</error>');
 
             return 1;
         }
 
-        if (file_exists($targetPublicPath.'/ckfinder/ckfinder.js')) {
+        if (file_exists($targetPublicPath . '/ckfinder/ckfinder.js')) {
             /** @var QuestionHelper $questionHelper */
             $questionHelper = $this->getHelper('question');
             $questionText =
-                'It looks like the CKFinder distribution package has already been installed. '.
+                'It looks like the CKFinder distribution package has already been installed. ' .
                 "This command will overwrite the existing files.\nDo you want to proceed? [y/N]: ";
             $question = new ConfirmationQuestion($questionText, false);
 
@@ -117,7 +117,7 @@ class CKFinderDownloadCommand extends Command
 
         $progressBar?->finish();
 
-        $output->writeln("\n".'Extracting CKFinder to the CKSourceCKFinderBundle::Resources/public directory.');
+        $output->writeln("\n" . 'Extracting CKFinder to the CKSourceCKFinderBundle::Resources/public directory.');
 
         if (false === $tempZipFile = tempnam(sys_get_temp_dir(), 'tmp')) {
             throw new \RuntimeException('Unable to create temporary file.');
@@ -139,7 +139,7 @@ class CKFinderDownloadCommand extends Command
                 throw new \RuntimeException(sprintf('Unable to get Zip entry name from index "%d".', $i));
             }
 
-            if (in_array($entry, $filesToKeep) && file_exists($targetPublicPath.'/'.$entry)) {
+            if (in_array($entry, $filesToKeep) && file_exists($targetPublicPath . '/' . $entry)) {
                 continue;
             }
 
@@ -156,18 +156,18 @@ class CKFinderDownloadCommand extends Command
 
         $output->writeln('Moving the CKFinder connector to the CKSourceCKFinderBundle::_connector directory.');
         $fs->mirror(
-            $targetPublicPath.'/ckfinder/core/connector/php/vendor/cksource/ckfinder/src/CKSource/CKFinder',
+            $targetPublicPath . '/ckfinder/core/connector/php/vendor/cksource/ckfinder/src/CKSource/CKFinder',
             $targetConnectorPath
         );
 
         $output->writeln('Cleaning up.');
         $fs->remove([
             $tempZipFile,
-            $targetPublicPath.'/ckfinder/core',
-            $targetPublicPath.'/ckfinder/userfiles',
-            $targetPublicPath.'/ckfinder/config.php',
-            $targetPublicPath.'/ckfinder/README.md',
-            $targetConnectorPath.'/README.md',
+            $targetPublicPath . '/ckfinder/core',
+            $targetPublicPath . '/ckfinder/userfiles',
+            $targetPublicPath . '/ckfinder/config.php',
+            $targetPublicPath . '/ckfinder/README.md',
+            $targetConnectorPath . '/README.md',
         ]);
 
         $output->writeln('Running code patchers...');

--- a/src/DependencyInjection/CKSourceCKFinderExtension.php
+++ b/src/DependencyInjection/CKSourceCKFinderExtension.php
@@ -72,12 +72,8 @@ class CKSourceCKFinderExtension extends Extension implements PrependExtensionInt
         $servicesMap = [];
 
         foreach ($config['connector']['backends'] as $backend) {
-            if ($backend['adapter'] === 's3') {
-                if (is_string($clientId = $backend['client'] ?? null)) {
-                    if (null === ($servicesMap[$clientId] ?? null)) {
-                        $servicesMap[$clientId] = new Reference($clientId);
-                    }
-                }
+            if ($backend['adapter'] === 's3' && is_string($clientId = $backend['client'] ?? null) && null === ($servicesMap[$clientId] ?? null)) {
+                $servicesMap[$clientId] = new Reference($clientId);
             }
         }
 

--- a/src/DependencyInjection/CKSourceCKFinderExtension.php
+++ b/src/DependencyInjection/CKSourceCKFinderExtension.php
@@ -28,7 +28,7 @@ class CKSourceCKFinderExtension extends Extension implements PrependExtensionInt
 {
     public function prepend(ContainerBuilder $container): void
     {
-        $fileLocator = new FileLocator(__DIR__.'/../Resources/config');
+        $fileLocator = new FileLocator(__DIR__ . '/../Resources/config');
 
         $loader = new Loader\PhpFileLoader($container, $fileLocator);
         $loader->load('ckfinder_config.php');
@@ -45,7 +45,7 @@ class CKSourceCKFinderExtension extends Extension implements PrependExtensionInt
      */
     public function load(array $configs, ContainerBuilder $container): void
     {
-        $fileLocator = new FileLocator(__DIR__.'/../Resources/config');
+        $fileLocator = new FileLocator(__DIR__ . '/../Resources/config');
 
         $loader = new Loader\YamlFileLoader($container, $fileLocator);
         $loader->load('services.yaml');
@@ -72,7 +72,7 @@ class CKSourceCKFinderExtension extends Extension implements PrependExtensionInt
         $servicesMap = [];
 
         foreach ($config['connector']['backends'] as $backend) {
-            if($backend['adapter'] === 's3') {
+            if ($backend['adapter'] === 's3') {
                 if (is_string($clientId = $backend['client'] ?? null)) {
                     if (null === ($servicesMap[$clientId] ?? null)) {
                         $servicesMap[$clientId] = new Reference($clientId);

--- a/src/Factory/ConnectorFactory.php
+++ b/src/Factory/ConnectorFactory.php
@@ -29,7 +29,7 @@ class ConnectorFactory
         /** @var CKFinder $connector */
         $connector = new $this->connectorConfig['connectorClass']($this->connectorConfig);
         $connector['authentication'] = $this->authenticationService;
-        $connector['services_map'] = function() {
+        $connector['services_map'] = function () {
             return $this->servicesMap;
         };
 

--- a/src/Factory/ConnectorFactory.php
+++ b/src/Factory/ConnectorFactory.php
@@ -4,6 +4,7 @@ namespace CKSource\Bundle\CKFinderBundle\Factory;
 
 use CKSource\Bundle\CKFinderBundle\Authentication\AuthenticationInterface;
 use CKSource\CKFinder\CKFinder;
+use Psr\Container\ContainerInterface;
 
 class ConnectorFactory
 {
@@ -14,7 +15,8 @@ class ConnectorFactory
      */
     public function __construct(
         protected array $connectorConfig,
-        protected AuthenticationInterface $authenticationService
+        protected AuthenticationInterface $authenticationService,
+        protected ContainerInterface $servicesMap,
     ) {
     }
 
@@ -27,6 +29,9 @@ class ConnectorFactory
         /** @var CKFinder $connector */
         $connector = new $this->connectorConfig['connectorClass']($this->connectorConfig);
         $connector['authentication'] = $this->authenticationService;
+        $connector['services_map'] = function() {
+            return $this->servicesMap;
+        };
 
         return $this->connectorInstance = $connector;
     }

--- a/src/Factory/ConnectorFactory.php
+++ b/src/Factory/ConnectorFactory.php
@@ -29,9 +29,7 @@ class ConnectorFactory
         /** @var CKFinder $connector */
         $connector = new $this->connectorConfig['connectorClass']($this->connectorConfig);
         $connector['authentication'] = $this->authenticationService;
-        $connector['services_map'] = function () {
-            return $this->servicesMap;
-        };
+        $connector['services_map'] = fn(): \Psr\Container\ContainerInterface => $this->servicesMap;
 
         return $this->connectorInstance = $connector;
     }

--- a/src/Factory/ConnectorFactory.php
+++ b/src/Factory/ConnectorFactory.php
@@ -29,7 +29,7 @@ class ConnectorFactory
         /** @var CKFinder $connector */
         $connector = new $this->connectorConfig['connectorClass']($this->connectorConfig);
         $connector['authentication'] = $this->authenticationService;
-        $connector['services_map'] = fn(): \Psr\Container\ContainerInterface => $this->servicesMap;
+        $connector['services_map'] = fn (): \Psr\Container\ContainerInterface => $this->servicesMap;
 
         return $this->connectorInstance = $connector;
     }

--- a/src/Form/Type/CKFinderFileChooserType.php
+++ b/src/Form/Type/CKFinderFileChooserType.php
@@ -45,7 +45,7 @@ class CKFinderFileChooserType extends AbstractType
         $view->vars['button_text'] = $options['button_text'];
         $view->vars['button_attr'] = $options['button_attr'];
         $view->vars['mode'] = $options['mode'];
-        $view->vars['button_id'] = 'ckf_filechooser_'.$view->vars['id'];
+        $view->vars['button_id'] = 'ckf_filechooser_' . $view->vars['id'];
     }
 
     public function getParent(): string

--- a/src/Patcher/BackendAwsS3ClientPatcher.php
+++ b/src/Patcher/BackendAwsS3ClientPatcher.php
@@ -27,8 +27,12 @@ class BackendAwsS3ClientPatcher implements PatcherInterface
             $client = new S3Client($clientConfig);
 PHP,
             <<<'PHP'
-            if (($backendConfig['client'] ?? null) instanceof S3Client) {
+            $client = ($backendConfig['client'] ?? null);
+            if ($client instanceof S3Client) {
                 $client = $backendConfig['client'];
+                unset($backendConfig['client']);
+            } elseif (is_string($client)) {
+                $client = $this->app['services_map']->get($client);
                 unset($backendConfig['client']);
             } else {
                 $clientConfig = [

--- a/src/Patcher/BackendAwsS3ClientPatcher.php
+++ b/src/Patcher/BackendAwsS3ClientPatcher.php
@@ -9,7 +9,7 @@ class BackendAwsS3ClientPatcher implements PatcherInterface
     public function patch(string $connectorPath): void
     {
         $this->patchFile(
-            $connectorPath.'/Backend/BackendFactory.php',
+            $connectorPath . '/Backend/BackendFactory.php',
             <<<'PHP'
             $clientConfig = [
                 'credentials' => [

--- a/src/Patcher/ScopedDependenciesPatcher.php
+++ b/src/Patcher/ScopedDependenciesPatcher.php
@@ -19,8 +19,8 @@ class ScopedDependenciesPatcher implements PatcherInterface
             ->contains(['use League\\', ' \\League']);
 
         foreach ($files as $file) {
-            $this->patchFile($file, 'use League\\', 'use \\'.self::PREFIX.'\\League\\', false);
-            $this->patchFile($file, ' \\League\\', ' \\'.self::PREFIX.'\\League\\', false);
+            $this->patchFile($file, 'use League\\', 'use \\' . self::PREFIX . '\\League\\', false);
+            $this->patchFile($file, ' \\League\\', ' \\' . self::PREFIX . '\\League\\', false);
         }
     }
 }

--- a/src/Patcher/Symfony54Patcher.php
+++ b/src/Patcher/Symfony54Patcher.php
@@ -9,25 +9,25 @@ class Symfony54Patcher implements PatcherInterface
     public function patch(string $connectorPath): void
     {
         $this->patchFile(
-            $connectorPath.'/CKFinder.php',
+            $connectorPath . '/CKFinder.php',
             'public function handle(Request $request, int $type = HttpKernelInterface::MAIN_REQUEST, bool $catch = true)',
             'public function handle(Request $request, int $type = HttpKernelInterface::MAIN_REQUEST, bool $catch = true): Response',
         );
 
         $this->patchFile(
-            $connectorPath.'/CommandResolver.php',
+            $connectorPath . '/CommandResolver.php',
             'public function getController(Request $request)',
             'public function getController(Request $request): callable|false',
         );
 
         $this->patchFile(
-            $connectorPath.'/ArgumentResolver.php',
+            $connectorPath . '/ArgumentResolver.php',
             'public function getArguments(Request $request, callable $command)',
             'public function getArguments(Request $request, callable $command): array',
         );
 
         $this->patchFile(
-            $connectorPath.'/Response/JsonResponse.php',
+            $connectorPath . '/Response/JsonResponse.php',
             'public function setData($data = [])',
             'public function setData(mixed $data = []): static',
         );

--- a/src/Resources/config/services.yaml
+++ b/src/Resources/config/services.yaml
@@ -8,7 +8,7 @@ services:
     ckfinder.connector.factory:
         class: '%ckfinder.connector.factory.class%'
         public: true
-        arguments: ['%ckfinder.connector.config%', '@ckfinder.connector.auth']
+        arguments: ['%ckfinder.connector.config%', '@ckfinder.connector.auth', null]
 
     ckfinder.connector:
         class: '%ckfinder.connector.class%'

--- a/tests/DependencyInjection/CKSourceCKFinderExtensionTest.php
+++ b/tests/DependencyInjection/CKSourceCKFinderExtensionTest.php
@@ -14,9 +14,7 @@ namespace CKSource\Bundle\CKFinderBundle\Tests\DependencyInjection;
 use _CKFinder_Vendor_Prefix\League\Flysystem\AwsS3v3\AwsS3Adapter;
 use _CKFinder_Vendor_Prefix\League\Flysystem\Cached\CachedAdapter;
 use Aws\S3\S3Client;
-use Aws\S3\S3ClientInterface;
 use CKSource\Bundle\CKFinderBundle\DependencyInjection\CKSourceCKFinderExtension;
-use CKSource\CKFinder\Backend\Adapter\AwsS3;
 use CKSource\CKFinder\Backend\Backend;
 use CKSource\CKFinder\Backend\BackendFactory;
 use CKSource\CKFinder\CKFinder;
@@ -63,7 +61,7 @@ class CKSourceCKFinderExtensionTest extends TestCase
      */
     protected function getConfig(): array
     {
-        return require __DIR__.'/../Fixtures/config/ckfinder_config.php';
+        return require __DIR__ . '/../Fixtures/config/ckfinder_config.php';
     }
 
     /**

--- a/tests/DependencyInjection/CKSourceCKFinderExtensionTest.php
+++ b/tests/DependencyInjection/CKSourceCKFinderExtensionTest.php
@@ -11,7 +11,13 @@
 
 namespace CKSource\Bundle\CKFinderBundle\Tests\DependencyInjection;
 
+use _CKFinder_Vendor_Prefix\League\Flysystem\AwsS3v3\AwsS3Adapter;
+use _CKFinder_Vendor_Prefix\League\Flysystem\Cached\CachedAdapter;
+use Aws\S3\S3Client;
+use Aws\S3\S3ClientInterface;
 use CKSource\Bundle\CKFinderBundle\DependencyInjection\CKSourceCKFinderExtension;
+use CKSource\CKFinder\Backend\Adapter\AwsS3;
+use CKSource\CKFinder\Backend\Backend;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
@@ -215,5 +221,39 @@ class CKSourceCKFinderExtensionTest extends TestCase
         $connector = $this->container->get('ckfinder.connector');
 
         static::assertEquals(['Files', 'Images'], $connector['config']->getResourceTypes());
+    }
+
+    /**
+     * Tests if a S3 Client reference can be defined in `client` option
+     */
+    public function testBackendS3Client(): void
+    {
+        $this->container->set('my_aws_s3_client', $s3Client = new S3Client([
+            'region' => 'eu-west-3',
+            'version' => 'latest',
+        ]));
+
+        $this->container->loadFromExtension($this->extensionAlias, [
+            'connector' => [
+                'backends' => [
+                    [
+                        'name' => 'default',
+                        'adapter' => 's3',
+                        'client' => 'my_aws_s3_client',
+                        'bucket' => 'my-bucket',
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->container->compile();
+
+        $connector = $this->container->get('ckfinder.connector');
+        $backend = $connector->getBackendFactory()->getBackend('default');
+
+        static::assertInstanceOf(Backend::class, $backend);
+        static::assertInstanceOf(CachedAdapter::class, $cachedAdapter = $backend->getAdapter());
+        static::assertInstanceOf(AwsS3Adapter::class, $awsS3Adapter = $cachedAdapter->getAdapter());
+        static::assertSame($s3Client, $awsS3Adapter->getClient());
     }
 }

--- a/tests/DependencyInjection/CKSourceCKFinderExtensionTest.php
+++ b/tests/DependencyInjection/CKSourceCKFinderExtensionTest.php
@@ -18,6 +18,8 @@ use Aws\S3\S3ClientInterface;
 use CKSource\Bundle\CKFinderBundle\DependencyInjection\CKSourceCKFinderExtension;
 use CKSource\CKFinder\Backend\Adapter\AwsS3;
 use CKSource\CKFinder\Backend\Backend;
+use CKSource\CKFinder\Backend\BackendFactory;
+use CKSource\CKFinder\CKFinder;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
@@ -249,8 +251,12 @@ class CKSourceCKFinderExtensionTest extends TestCase
         $this->container->compile();
 
         $connector = $this->container->get('ckfinder.connector');
-        $backend = $connector->getBackendFactory()->getBackend('default');
+        static::assertInstanceOf(CKFinder::class, $connector);
 
+        $backendFactory = $connector->getBackendFactory();
+        static::assertInstanceOf(BackendFactory::class, $backendFactory);
+
+        $backend = $backendFactory->getBackend('default');
         static::assertInstanceOf(Backend::class, $backend);
         static::assertInstanceOf(CachedAdapter::class, $cachedAdapter = $backend->getAdapter());
         static::assertInstanceOf(AwsS3Adapter::class, $awsS3Adapter = $cachedAdapter->getAdapter());

--- a/tests/Form/Type/CKFinderFileChooserTypeTest.php
+++ b/tests/Form/Type/CKFinderFileChooserTypeTest.php
@@ -47,7 +47,7 @@ class CKFinderFileChooserTypeTest extends TypeTestCase
         static::assertSame('popup', $view->vars['mode']);
         static::assertSame('Browse', $view->vars['button_text']);
         static::assertSame([], $view->vars['button_attr']);
-        static::assertSame('ckf_filechooser_'.$view->vars['id'], $view->vars['button_id']);
+        static::assertSame('ckf_filechooser_' . $view->vars['id'], $view->vars['button_id']);
     }
 
     public function testModeOptionExpectsModalOrPopup(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | Close #18   <!-- #-prefixed issue number(s), if any -->

Passing a service reference for a S3 adapter will now correctly resolves to the service instance.