### PR TITLE
feat(config:command:get-files): implement `returnMaxLastFiles` configuration

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -167,6 +167,17 @@ class Configuration implements ConfigurationInterface
             ->booleanNode('sessionWriteClose')->defaultTrue()->end()
             ->booleanNode('csrfProtection')->defaultTrue()->end()
             ->booleanNode('forceThrowExceptions')->defaultFalse()->end()
+            ->arrayNode('commands')
+                ->addDefaultsIfNotSet()
+                ->children()
+                    ->arrayNode('GetFiles')
+                        ->addDefaultsIfNotSet()
+                        ->children()
+                            ->integerNode('returnMaxLastFiles')->defaultNull()->end()
+                        ->end()
+                    ->end()
+                ->end()
+            ->end()
         ->end();
 
         return $connectorNode;

--- a/src/Patcher/GetFilesCommandPatcher.php
+++ b/src/Patcher/GetFilesCommandPatcher.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CKSource\Bundle\CKFinderBundle\Patcher;
+
+class GetFilesCommandPatcher implements PatcherInterface
+{
+    use PatcherTrait;
+
+    public function patch(string $connectorPath): void
+    {
+        $this->patchFile(
+            $connectorPath . '/Command/GetFiles.php',
+            "        \$data = new \\stdClass();",
+            "        \$commandConfig = \$this->app['config']->get('commands')['GetFiles'] ?? [];\n        \$data = new \\stdClass();",
+        );
+
+        $this->patchFile(
+            $connectorPath . '/Command/GetFiles.php',
+            "        \$files = \$workingFolder->listFiles();",
+            <<<'PHP'
+        $files = $workingFolder->listFiles();
+        
+        if (is_int($commandConfig['returnMaxLastFiles'] ?? null)) {
+            usort($files, function ($a, $b) {
+                return $a['timestamp'] <=> $b['timestamp'];
+            });
+            
+            $files = array_slice($files, 0, $commandConfig['returnMaxLastFiles']);
+        }
+PHP,
+        );
+    }
+}

--- a/src/Resources/config/services.yaml
+++ b/src/Resources/config/services.yaml
@@ -46,3 +46,7 @@ services:
     CKSource\Bundle\CKFinderBundle\Patcher\ForceThrowExceptions:
         tags:
             - { name: ckfinder.patcher, priority: 100 }
+
+    CKSource\Bundle\CKFinderBundle\Patcher\GetFilesCommandPatcher:
+        tags:
+            - { name: ckfinder.patcher, priority: 10 }

--- a/tests/Fixtures/config/ckfinder_config.php
+++ b/tests/Fixtures/config/ckfinder_config.php
@@ -105,5 +105,10 @@ $config['tempDirectory'] = sys_get_temp_dir();
 $config['sessionWriteClose'] = true;
 $config['csrfProtection'] = true;
 $config['forceThrowExceptions'] = false;
+$config['commands'] = [
+    'GetFiles' => [
+        'returnMaxLastFiles' => null
+    ],
+];
 
 return $config;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | Close #...   <!-- #-prefixed issue number(s), if any -->

<!--
Write a short README entry for your feature/bugfix here (replace this comment block.),
this will help people understand your PR.
-->

In our Wamiz CMS application, we have around 22k files which takes around ~40sec to render on a M1 Pro and that's a big issue, CKFinder is unusable for some team's people: 
![image](https://user-images.githubusercontent.com/2103975/223992205-1d6ed1d3-539a-4927-8409-5199c1cd4f54.png)

The idea between `returnMaxLastFiles` config is to limit the number of last files (ordered by date desc) to return, this way we filter too old files, and reduce DOM operations. 